### PR TITLE
`onSampleRateChange()` not needed from module ctor

### DIFF
--- a/src/Cosmos.cpp
+++ b/src/Cosmos.cpp
@@ -126,9 +126,6 @@ struct Cosmos : Module {
 		configOutput(XNOR_OUTPUT, "XNOR (inverted through-zero clipper)");
 		configOutput(XNOR_GATE_OUTPUT, "XNOR gate");
 		configOutput(XNOR_TRIG_OUTPUT, "XNOR trigger");
-
-		// calculate up/downsampling rates
-		onSampleRateChange();
 	}
 
 	void onSampleRateChange() override {

--- a/src/SlewLFO.cpp
+++ b/src/SlewLFO.cpp
@@ -60,9 +60,6 @@ struct SlewLFO : Module {
 		configInput(IN_INPUT, "In");
 		configOutput(OUT_OUTPUT, "Out");
 
-		// calculate up/downsampling rates
-		onSampleRateChange();
-
 		updateCounter.setDivision(128);
 	}
 


### PR DESCRIPTION
See here: https://community.vcvrack.com/t/rack-samplerate-not-returning-value-when-compile-in-windows/22923/16

Also clears cppcheck warnings: 
``
cppcheck++: warning
virtualCallInConstructor - Virtual function 'onSampleRateChange' is called from constructor 'Cosmos()' at line 131. Dynamic binding is not used.
``
``
cppcheck++: warning
virtualCallInConstructor - Virtual function 'onSampleRateChange' is called from constructor 'SlewLFO()' at line 64. Dynamic binding is not used.
``